### PR TITLE
Added clause to ensure sent forms are required to send out responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The official constitution of the UNSW Security Society.
 
 # 7 ADDITIONS
     7.1 As per new requirements from Arc, the executive team of the club are now responsible for the maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
-    
-    Please number any further additions or alterations to this Constitution starting with 7.2, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
+    7.2 Any forms to be sent from the society to its members (unless marked anonymous), are required to always send out response receipts.
+
+    Please number any further additions or alterations to this Constitution starting with 7.3, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
 


### PR DESCRIPTION
Added clause to ensure sent forms are required to send out responses receipts.
This allows for members to own a receipt to prove any form submissions.