### PR TITLE
Grammar, formatting, spelling, and administrative suggestions from Arc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The official constitution of the UNSW Security Society.
     1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E.R. Renton shall apply.
 
 ## DEFINITIONS
-
     1.5 For the purposes of this Constitution:
       1.5.1 The University shall mean the University of New South Wales;
       1.5.2 Arc shall mean Arc @ UNSW Limited;
@@ -183,7 +182,6 @@ The official constitution of the UNSW Security Society.
       4.13.3 When requested by three (3) members of the Committee; and
       4.13.4 In open session unless the Executive resolves to discuss a matter in closed session.
         4.13.4.1 Open session meetings are to be publicised a week in advance to the meeting date.
-
     4.14 Valid Executive Resolutions shall require:
       4.14.1 That the matter to be dealt with by resolution be identified as an agenda item when notice of the relevant meeting is sent to executive members, unless by unanimous resolution of present voting executive members, it is declared the matter shall be dealt with;
       4.14.2 That at least 50% of voting members of the executive be present when the resolution is passed;

--- a/README.md
+++ b/README.md
@@ -173,9 +173,8 @@ The official constitution of the UNSW Security Society.
 ## Meetings
     4.12 General requirements for all meetings are as follows:
       4.12.1 All Executive Resolutions (Voting) at meetings shall subject to requirements outlined in Section 4.13; and
-      4.12.2 Meetings shall be conducted in accordance with Section 4.12; and
-      4.12.3 Approved minutes of Executive meetings shall be available to members;
-        4.12.3.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
+      4.12.2 Approved minutes of Executive meetings shall be available to members;
+        4.12.2.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
     4.13 Meetings shall be conducted:
       4.13.1 At least once per month; and
         4.13.1.1 Unless otherwise agreed upon by a majority of the executive

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The official constitution of the UNSW Security Society.
 
 # 2 MEMBERSHIP
     2.1 Contact details for members of your club are to remain with the Executive and Arc to have sole access. Contact details are not to be given or sold to any other person.
-    2.2 The club shall be recognized as a Financial club.
+    2.2 The club shall be recognised as a Financial club.
     2.3 Full membership of the club shall be open to all UNSW students subject to affiliation requirements of Arc, and they shall be required to pay an annual club membership fee of at least $0, and complete a membership form.
     2.4 Associate membership shall be open to all persons who are not UNSW students subject to affiliation requirements of Arc, provided that they pay a membership fee that is set by the club Executive, and they complete a membership form prepared by the club Executive.
     2.5 The duration of a person's membership shall be until the club's next Annual General Meeting after they have become a member, or until the end of Week One in Term One of the University year after they have become a member, whichever is the later.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The official constitution of the UNSW Security Society.
 
 ## Meetings
     4.12 General requirements for all meetings are as follows:
-      4.12.1 All Executive Resolutions (Voting) at meetings shall subject to requirements outlined in Section 4.13; and
+      4.12.1 All Executive Resolutions (Voting) at meetings shall be subject to requirements outlined in Section 4.13; and
       4.12.2 Approved minutes of Executive meetings shall be available to members;
         4.12.2.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
     4.13 Meetings shall be conducted:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The official constitution of the UNSW Security Society.
     3.4 The Executive shall be responsible for the following duties:
       3.4.1 The activities of the club;
       3.4.2 The finances of the club;
+      3.4.3 The maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
     3.5 The Executive is at all times bound by the decisions of a club Annual or Extraordinary General Meeting.
     3.6 Any member of the Executive shall have their position declared vacant if they:
       3.6.1 Die;
@@ -257,7 +258,5 @@ The official constitution of the UNSW Security Society.
     6.3 On dissolution of the club, the club is not to distribute assets to members. All assets are to be distributed to an organisation with similar goals or objectives that also prohibits the distribution of assets to members. This organisation may be nominated at the dissolution meeting of the club. If no other legitimate club or organisation is nominated, Arc will begin procedures to recover any property, monies or records belonging to the club which it perceives would be useful to other Arc-affiliated clubs. The club will be given twenty one (21) days to forward all relevant items to Arc before any action is instigated.
 
 # 7 ADDITIONS
-    7.1 As per new requirements from Arc, the executive team of the club are now responsible for the maintenance and review of policies & procedures of the Club, including its Grievance Resolution Policy & Procedure.
-
-    Please number any further additions or alterations to this Constitution starting with 7.2, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
+    Please number any further additions or alterations to this Constitution starting with 7.1, and ensure that a copy is submitted to Arc with your affiliation. Additions or alterations to this Constitution do not become valid unless ratified by Arc.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The official constitution of the UNSW Security Society.
     2.2 The club shall be recognized as a Financial club.
     2.3 Full membership of the club shall be open to all UNSW students subject to affiliation requirements of Arc, and they shall be required to pay an annual club membership fee of at least $0, and complete a membership form.
     2.4 Associate membership shall be open to all persons who are not UNSW students subject to affiliation requirements of Arc, provided that they pay a membership fee that is set by the club Executive, and they complete a membership form prepared by the club Executive.
-    2.5 The duration of a person's membership shall be until the club's next Annual General Meeting after they have become a member, or until the end of Week One in Session One of the University year after they have become a member, whichever is the later.
+    2.5 The duration of a person's membership shall be until the club's next Annual General Meeting after they have become a member, or until the end of Week One in Term One of the University year after they have become a member, whichever is the later.
     2.6 The club shall comply with anti-discrimination legislation in all of its activities and procedures, including the granting of club membership.
     2.7 Notwithstanding clause 2.8, a member of a club Executive may have their position declared vacant according to the procedures set out in Section 3.6.
     2.8 Notwithstanding clause 2.8, a member or associate member of a club may have their membership terminated after the following procedure is followed:

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The official constitution of the UNSW Security Society.
 # 1 INTRODUCTION
     1.1 The official name of the club shall be "The Security Society of UNSW".
     1.2 The club shall be affiliated to Arc.
-    1.3 The aims and objectives of the club are:
-      1.3.1 Spreading awareness of security in its many forms, including computer and real life.
-      1.3.2 Host events to facilitate the development of skills and knowledge of security.
+    1.3 The aims and objectives of the club are to:
+      1.3.1 Spread awareness of security in its many forms, including computer and real life;
+      1.3.2 Host events to facilitate the development of skills and knowledge of security; and
       1.3.3 Provide networking opportunities between students and companies in the security industry.
     1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E.R. Renton shall apply.
 
@@ -37,8 +37,8 @@ The official constitution of the UNSW Security Society.
     2.8 Notwithstanding clause 2.9, a member or associate member of a club may have their membership terminated after the following procedure is followed:
       2.8.1 A motion is carried by the Executive, or the Executive is petitioned by fifteen (15) members to instigate impeachment proceedings;
       2.8.2 The members of the club are notified of the proceedings formally as a motion on notice to an Extraordinary General Meeting under Section 4.2;
-      2.8.3 The member concerned is notified in writing of the procedures and reasons for proceedings at least seven (7) days prior to the meeting.
-      2.8.4 The member concerned is given five (5) minutes to speak against the motion at the Extraordinary General Meeting.
+      2.8.3 The member concerned is notified in writing of the procedures and reasons for proceedings at least seven (7) days prior to the meeting;
+      2.8.4 The member concerned is given five (5) minutes to speak against the motion at the Extraordinary General Meeting; and
       2.8.5 The motion is carried by the Extraordinary General Meeting.
     2.9 Any member of a club or club Executive who believes they have been wrongly expelled may appeal to Arc, who will arrive at the final resolution of the matter.
 
@@ -134,10 +134,10 @@ The official constitution of the UNSW Security Society.
         b) To communicate with the Executive before and after each Arc Clubs General Meeting to pass on information (about grants etc);
         c) To liaise with Arc and the club's Executive;
         d) To have a good working knowledge of Arc forms;
-        e) To clear out the club's pigeonhole in the Arc Resource Centre at least every two (2) weeks; and
-        f) To attend Arc Clubs General Meetings or nominate a fellow club member to attend on your behalf, or send advance apologies (taking the form of a written note detailing your name, club, and the date of the meeting you can not attend).
-        g) To ensure that Arc is informed of any changes to the Executive;
-        h) To ensure that changes made to the constitution at an EGM or AGM are in line with Arc requirements;
+        e) To clear out the club's pigeonhole in the Arc Resource Centre at least every two (2) weeks;
+        f) To attend Arc Clubs General Meetings or nominate a fellow club member to attend on your behalf, or send advance apologies (taking the form of a written note detailing your name, club, and the date of the meeting you can not attend);
+        g) To ensure that Arc is informed of any changes to the Executive; and
+        h) To ensure that changes made to the constitution at an EGM or AGM are in line with Arc requirements.
 
     3.9 Committee Members
       3.9.1 Committee positions are to be determined by the executive.
@@ -153,7 +153,7 @@ The official constitution of the UNSW Security Society.
 ## Annual General Meetings
     4.1 There shall be one (1) Annual General meeting every calendar year.
     4.2 Notice in the form of an agenda for the Annual General Meeting shall be no less than seven (7) days, and is to be:
-      4.2.1 Given in writing to Arc;
+      4.2.1 Given in writing to Arc; and
       4.2.2 Given in writing to all club members, or upon approval by Arc displayed in a way that will guarantee an acceptable level of exposure among club members.
     4.3 Quorum for the Annual General Meeting shall be fifteen (15) members or one half of the club membership, whichever is the lesser. This is based on the membership list at the time that notice of the meeting is given.
     4.4 At an Annual General Meeting:
@@ -177,12 +177,12 @@ The official constitution of the UNSW Security Society.
       4.12.2 Approved minutes of Executive meetings shall be available to members;
         4.12.2.1 Approved minutes may exclude, however is not limited to excluding: sponsorship discussions, committee nomination discussions and other internal private matters;
     4.13 Meetings shall be conducted:
-      4.13.1 At least once per month; and
+      4.13.1 At least once per month;
         4.13.1.1 Unless otherwise agreed upon by a majority of the executive
-      4.13.2 When called upon by the President; and
+      4.13.2 When called upon by the President;
       4.13.3 When requested by three (3) members of the Committee; and
-      4.13.4 In open session unless the Executive resolves to discuss a matter in closed session;
-        4.13.4.1 Open session meetings are to be publicised a week in advance to the meeting date;
+      4.13.4 In open session unless the Executive resolves to discuss a matter in closed session.
+        4.13.4.1 Open session meetings are to be publicised a week in advance to the meeting date.
 
     4.14 Valid Executive Resolutions shall require:
       4.14.1 That the matter to be dealt with by resolution be identified as an agenda item when notice of the relevant meeting is sent to executive members, unless by unanimous resolution of present voting executive members, it is declared the matter shall be dealt with;
@@ -193,23 +193,23 @@ The official constitution of the UNSW Security Society.
 
 ## Elections
     4.15 Elections of executive will be conducted at the Annual General Meeting (or Extraordinary General Meetings where relevant) following the requirements set out in this constitution.
-    4.16 Elections requirements are stated as follows;
+    4.16 Elections requirements are stated as follows:
       4.16.1 Optional preferential voting shall be used;
       4.16.2 Voting for all positions shall be conducted simultaneously (where applicable);
       4.16.3 A Returning Officer shall be appointed by the Executive, informed by the first notice of the election;
       4.16.4 Members who nominate themselves for candidacy for more than one (1) position must provide an order of preference;
       4.16.5 If a candidate wins more than one (1) position, the candidate shall be elected to their most preferred position, and votes for the vacated position(s) shall be counted again (unless there are no other candidates in the vacated position).
-      4.16.6 If nominations are taken in advance:;
+      4.16.6 If nominations are taken in advance:
         4.16.6.1 All eligible members must receive notice of the nominations period before its commencement, as well as details of the nomination process.
         4.16.6.2 Nominations must be open for at least seven (7) days.
-        4.16.6.3 Members who wish to submit themselves as nomination candidate:;
-          4.16.6.3.1 Must do so directly to the Returning Officer;
+        4.16.6.3 Members who wish to submit themselves as nomination candidate:
+          4.16.6.3.1 Must do so directly to the Returning Officer; and
           4.16.6.3.2 Must confirm their nomination by emailing the returning officer using their UNSW email, before voting begins.
         4.16.6.4 Only the returning officer may view the list of nominations until nominations have closed.
         4.16.6.5 At the start of the voting period:
           4.16.6.5.1 An official ballot shall be sent to members;
-          4.16.6.5.2 The ballot will disclose the preferred position of each confirmed candidate;
-          4.16.6.5.3 The order of candidates for each position on the ballot will be random;
+          4.16.6.5.2 The ballot will disclose the preferred position of each confirmed candidate; and
+          4.16.6.5.3 The order of candidates for each position on the ballot will be random.
         4.16.6.6 For any position for which there are no confirmed candidates at the close of nominations, nominations for those positions will be valid if received at the General Meeting.
     4.17 All election candidates:
       4.17.1 Must not run in coalitions.
@@ -225,19 +225,19 @@ The official constitution of the UNSW Security Society.
         4.18.1.3 All present members shall be provided a paper ballot;
         4.18.1.4 Candidates may campaign at the meeting before voting begins. If unable to do so, the Returning Officer shall read out their blurb, if any was provided.
       4.18.2 Online Elections
-        4.18.2.1 At least two (2) weeks before the election;
-          4.18.2.1.1 Nominations will open,
-          4.18.2.1.2 and members will be notified that they need to sign up to the society on SpArc before voting begins to be eligible to vote.
-        4.18.2.2 At least one (1) week before the election;
-          4.18.2.2.1 Nominations will close,
-          4.18.2.2.2 candidates may start campaigning,
-          4.18.2.2.3 and voting will begin, where official ballots shall only be sent to all members who have signed up to the society on SpArc.
+        4.18.2.1 At least two (2) weeks before the election:
+          4.18.2.1.1 Nominations will open; and
+          4.18.2.1.2 Members will be notified that they need to sign up to the society on SpArc before voting begins to be eligible to vote.
+        4.18.2.2 At least one (1) week before the election:
+          4.18.2.2.1 Nominations will close;
+          4.18.2.2.2 Candidates may start campaigning; and
+          4.18.2.2.3 Voting will begin, where official ballots shall only be sent to all members who have signed up to the society on SpArc.
         4.18.2.3 The results are to be declared at a General Meeting held within fourteen (14) days of the conclusion of voting.
     4.19 AGM Elections
       4.19.1 At least three (3) weeks prior to the AGM date, notice of the AGM and nomination procedure shall be given to members.
       4.19.2 Seven (7) days prior to the AGM, the official voting ballot shall be sent to members;
 
-# 5 FINANCE;
+# 5 FINANCE
     5.1 The club shall hold an account with a financial institution approved by Arc;
     5.2 The Executive must approve all accounts and expenditures for payment;
     5.3 All financial transactions shall require two (2) signatures of members of the Executive;
@@ -245,7 +245,7 @@ The official constitution of the UNSW Security Society.
     5.5 The financial records of the club shall be open for inspection by Arc at all times.
     5.6 The assets and income of the club shall be applied solely in furtherance of its above-mentioned objects and no portion shall be distributed directly or indirectly to the members of the club except as bona fide compensation for services rendered or expenses incurred on behalf of the club.
 
-# 6 DISSOLUTION;
+# 6 DISSOLUTION
     6.1 Dissolution of the club will occur after the following conditions have been met:
       6.1.1 An Extraordinary General Meeting is petitioned in writing as set out in 4.8;
       6.1.2 Procedures for notification as set out in 4.2 are followed, and the reasons for the proposed dissolution are included with the notification to Arc;

--- a/README.md
+++ b/README.md
@@ -205,14 +205,14 @@ The official constitution of the UNSW Security Society.
           4.16.6.3.1 Must do so directly to the Returning Officer;
           4.16.6.3.2 Must confirm their nomination by emailing the returning officer using their UNSW email, before voting begins.
         4.16.6.4 Only the returning officer may view the list of nominations until nominations have closed.
-        4.16.6.5 At the start of the voting period:;
+        4.16.6.5 At the start of the voting period:
           4.16.6.5.1 An official ballot shall be sent to members;
           4.16.6.5.2 The ballot will disclose the preferred position of each confirmed candidate;
           4.16.6.5.3 The order of candidates for each position on the ballot will be random;
         4.16.6.6 For any position for which there are no confirmed candidates at the close of nominations, nominations for those positions will be valid if received at the General Meeting.
-    4.17 All election candidates:;
+    4.17 All election candidates:
       4.17.1 Must not run in coalitions.
-      4.17.2 May campaign for their positions subject to the following procedures:;
+      4.17.2 May campaign for their positions subject to the following procedures:
         4.17.2.1 The current or outgoing executives, or committee may not support or criticise any candidate for election;
       4.17.3 At the General Meeting at which the election was held (unless they are the only candidate for a position), will have their elected position given to the next candidate in line if:
         4.17.3.1 They do not attend (unless the candidate has given an excuse).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The official constitution of the UNSW Security Society.
       1.5.6 The Executive shall mean the Executive of the club;
       1.5.7 The Committee shall mean the Executive of the club as well as any member appointed by the Executive to fill a specific role;
       1.5.8 The Annual General Meeting shall mean the Annual General Meeting of the club;
-      1.5.9 An academic day shall mean a day during the first or second session of the University's academic year which is not a Saturday, Sunday, Public Holiday or University Holiday; and
+      1.5.9 An academic day shall mean a day during the first, second, or third term of the University's academic year which is not a Saturday, Sunday, Public Holiday or University Holiday; and
       1.5.10 Subjects shall mean units of study offered by the University in progression to the award of a degree.
     1.6 Unless a contrary statement appears in Section 7 of this Constitution, the club shall be bound by all the clauses in Section 2 to Section 6 of this Constitution.
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ The official constitution of the UNSW Security Society.
       3.8.2 Vice President
         a) In the absence of the President, to chair all meetings (held during their term) of the club or society;
         b) To be responsible for matters relating to sponsorship and funding from outside organisations other than Arc, including but not limited to:
-            i. Liaising with such outside organisations,
-           ii. Establishing the sponsorship proposal for the year, and
-          iii. Organising events run in conjunction with sponsors;
+            i. Liaising with such outside organisations;
+           ii. Establishing the sponsorship proposal for the year; and
+          iii. Organising events run in conjunction with sponsors.
         c) To be responsible for matters relating to grievances, including but not limited to:
-            i. To receive complaints and grievances relating to the Club,
-           ii. To investigate grievances (where necessary) and resolve grievances or make recommendations to the Club Executive on the resolution of grievances,
-          iii. To act in a fair, ethical and confidential manner in the performance of their duties, and pass on their responsibilities for specific grievances to other Club Executives if they cannot act impartially, and
-           iv. To notify those involved of the outcome of the grievance;
+            i. To receive complaints and grievances relating to the Club;
+           ii. To investigate grievances (where necessary) and resolve grievances or make recommendations to the Club Executive on the resolution of grievances;
+          iii. To act in a fair, ethical and confidential manner in the performance of their duties, and pass on their responsibilities for specific grievances to other Club Executives if they cannot act impartially; and
+           iv. To notify those involved of the outcome of the grievance.
         d) To arrive at a budget with the Executive;
         e) To assist the President in coordinating the activities and administration of the Club;
         f) To have a thorough knowledge of the Club's constitution;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official constitution of the UNSW Security Society.
 
 # 1 INTRODUCTION
     1.1 The official name of the club shall be "The Security Society of UNSW".
-    1.2 The club shall be affiliated to Arc.
+    1.2 The club shall be affiliated with Arc.
     1.3 The aims and objectives of the club are to:
       1.3.1 Spread awareness of security in its many forms, including computer and real life;
       1.3.2 Host events to facilitate the development of skills and knowledge of security; and

--- a/README.md
+++ b/README.md
@@ -212,11 +212,12 @@ The official constitution of the UNSW Security Society.
           4.16.6.5.3 The order of candidates for each position on the ballot will be random.
         4.16.6.6 For any position for which there are no confirmed candidates at the close of nominations, nominations for those positions will be valid if received at the General Meeting.
     4.17 All election candidates:
-      4.17.1 Must not run in coalitions.
+      4.17.1 Must not run in coalitions; and
       4.17.2 May campaign for their positions subject to the following procedures:
         4.17.2.1 The current or outgoing executives, or committee may not support or criticise any candidate for election;
       4.17.3 At the General Meeting at which the election was held (unless they are the only candidate for a position), will have their elected position given to the next candidate in line if:
-        4.17.3.1 They do not attend (unless the candidate has given an excuse).
+        4.17.3.1 They do not attend (unless the candidate has given an excuse),
+or
         4.17.3.2 They wish to no longer accept their position.
     4.18 Elections may take place as one of the following forms, provided they satisfy all existing election requirements as set out in this constitution and their requirements as set out below:
       4.18.1 Ballot Elections

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The official constitution of the UNSW Security Society.
         n) Under no circumstances are any expenses to be met without documentation.
 
       3.8.5 Arc Delegate
-        a) To be aware of the Arc funding system, it's requirements and its possibilities for the club;
+        a) To be aware of the Arc funding system, its requirements and its possibilities for the club;
         b) To communicate with the Executive before and after each Arc Clubs General Meeting to pass on information (about grants etc);
         c) To liaise with Arc and the club's Executive;
         d) To have a good working knowledge of Arc forms;

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The official constitution of the UNSW Security Society.
 ## Extraordinary General Meetings
     4.6 There shall be Extraordinary General Meetings as the Executive sees fit or as petitioned under clause 4.8.
     4.7 The format, procedures, notice and quorum for an Extraordinary General Meeting shall be the same as for an Annual General Meeting, except that Executive elections will not be held unless specifically notified.
-    4.8 To petition Extraordinary General Meeting fifteen (15) members or half of the club membership, whichever is the lesser, must petition the Executive in writing.
+    4.8 To petition for an Extraordinary General Meeting, fifteen (15) members or half of the club membership, whichever is the lesser, must petition the Executive in writing.
     4.9 Such a petitioned meeting must be held within twenty-one (21) days, but no sooner than seven (7) days.
     4.10 There shall be other general meetings of the club as the Executive sees fit.
     4.11 Proxies are not allowed at General, Annual General or Extraordinary General Meetings.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The official constitution of the UNSW Security Society.
     4.4 At an Annual General Meeting:
       4.4.1 Reports shall be presented by at least the President and the Treasurer;
       4.4.2 Full financial reports shall be presented and adopted;
-      4.4.3 Elections for a new Executive shall be conducted in accordance with Section 4.14; and
+      4.4.3 Elections for a new Executive shall be conducted; and
       4.4.4 Constitutional amendments and other motions on notice may be discussed and voted upon.
     4.5 Full minutes of this meeting, including a list of the new Executive, written financial reports, and constitutional amendments, shall be forwarded to Arc within fourteen (14) days of the meeting.
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ The official constitution of the UNSW Security Society.
       4.17.2 May campaign for their positions subject to the following procedures:
         4.17.2.1 The current or outgoing executives, or committee may not support or criticise any candidate for election;
       4.17.3 At the General Meeting at which the election was held (unless they are the only candidate for a position), will have their elected position given to the next candidate in line if:
-        4.17.3.1 They do not attend (unless the candidate has given an excuse),
-or
+        4.17.3.1 They do not attend (unless the candidate has given an excuse), or
         4.17.3.2 They wish to no longer accept their position.
     4.18 Elections may take place as one of the following forms, provided they satisfy all existing election requirements as set out in this constitution and their requirements as set out below:
       4.18.1 Ballot Elections

--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ The official constitution of the UNSW Security Society.
       6.1.6 A vote is taken and the motion to dissolve lapses if opposed by fifteen (15) or more members of the club;
       6.1.7 If the motion to dissolve is carried, Arc must be notified within fourteen (14) days;
     6.2 Dissolution of the club will also occur if the club has been financially and administratively inactive for a period of eighteen (18) months;
-      6.2.1 Arc must give twenty (20) academic days notice in an official Arc publication and in writing to the last known President before dissolving the club in this way;
     6.3 On dissolution of the club, the club is not to distribute assets to members. All assets are to be distributed to an organisation with similar goals or objectives that also prohibits the distribution of assets to members. This organisation may be nominated at the dissolution meeting of the club. If no other legitimate club or organisation is nominated, Arc will begin procedures to recover any property, monies or records belonging to the club which it perceives would be useful to other Arc-affiliated clubs. The club will be given twenty one (21) days to forward all relevant items to Arc before any action is instigated.
 
 # 7 ADDITIONS

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The official constitution of the UNSW Security Society.
         k) To ensure you have at least two (2) and not more than three (3) signatories who are Executive members to the cheque account;
         l) To ensure that club funds are not misused at any time; and
         m) To ensure that when smaller amounts of money are spent (petty cash) a receipt or docket must be obtained.
-        n) Under no circumstances are any expenses to be met without documentation,
+        n) Under no circumstances are any expenses to be met without documentation.
 
       3.8.5 Arc Delegate
         a) To be aware of the Arc funding system, it's requirements and its possibilities for the club;

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ The official constitution of the UNSW Security Society.
         i) To always enter the payees name, the cheque amount and a brief explanation of the payment on the cheque butt;
         j) To always provide a receipt to a person who gives money to the club for any reason and bank all money received IMMEDIATELY;
         k) To ensure you have at least two (2) and not more than three (3) signatories who are Executive members to the cheque account;
-        l) To ensure that club funds are not misused at any time; and
-        m) To ensure that when smaller amounts of money are spent (petty cash) a receipt or docket must be obtained.
-        n) Under no circumstances are any expenses to be met without documentation.
+        l) To ensure that club funds are not misused at any time;
+        m) To ensure that when smaller amounts of money are spent (petty cash) a receipt or docket must be obtained; and
+        n) To ensure that under no circumstances are any expenses to be met without documentation.
 
       3.8.5 Arc Delegate
         a) To be aware of the Arc funding system, its requirements and its possibilities for the club;

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The official constitution of the UNSW Security Society.
     2.4 Associate membership shall be open to all persons who are not UNSW students subject to affiliation requirements of Arc, provided that they pay a membership fee that is set by the club Executive, and they complete a membership form prepared by the club Executive.
     2.5 The duration of a person's membership shall be until the club's next Annual General Meeting after they have become a member, or until the end of Week One in Term One of the University year after they have become a member, whichever is the later.
     2.6 The club shall comply with anti-discrimination legislation in all of its activities and procedures, including the granting of club membership.
-    2.7 Notwithstanding clause 2.8, a member of a club Executive may have their position declared vacant according to the procedures set out in Section 3.6.
-    2.8 Notwithstanding clause 2.8, a member or associate member of a club may have their membership terminated after the following procedure is followed:
+    2.7 Notwithstanding clause 2.9, a member of a club Executive may have their position declared vacant according to the procedures set out in Section 3.6.
+    2.8 Notwithstanding clause 2.9, a member or associate member of a club may have their membership terminated after the following procedure is followed:
       2.8.1 A motion is carried by the Executive, or the Executive is petitioned by fifteen (15) members to instigate impeachment proceedings;
       2.8.2 The members of the club are notified of the proceedings formally as a motion on notice to an Extraordinary General Meeting under Section 4.2;
       2.8.3 The member concerned is notified in writing of the procedures and reasons for proceedings at least seven (7) days prior to the meeting.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official constitution of the UNSW Security Society.
       1.3.1 Spreading awareness of security in its many forms, including computer and real life.
       1.3.2 Host events to facilitate the development of skills and knowledge of security.
       1.3.3 Provide networking opportunities between students and companies in the security industry.
-    1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organizations by N.E.R. Renton shall apply.
+    1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E.R. Renton shall apply.
 
 ## DEFINITIONS
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official constitution of the UNSW Security Society.
       1.3.1 Spread awareness of security in its many forms, including computer and real life;
       1.3.2 Host events to facilitate the development of skills and knowledge of security; and
       1.3.3 Provide networking opportunities between students and companies in the security industry.
-    1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E.R. Renton shall apply.
+    1.4 In all matters not specifically dealt with herein, the procedures set out in the latest edition of Guide for Meetings and Organisations by N.E. Renton shall apply.
 
 ## DEFINITIONS
     1.5 For the purposes of this Constitution:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The official constitution of the UNSW Security Society.
     4.2 Notice in the form of an agenda for the Annual General Meeting shall be no less than seven (7) days, and is to be:
       4.2.1 Given in writing to Arc;
       4.2.2 Given in writing to all club members, or upon approval by Arc displayed in a way that will guarantee an acceptable level of exposure among club members.
-    4.3 Quorum for the Annual General Meeting shall be fifteen (15) members or one half of the club membership, whichever is the lesser.
+    4.3 Quorum for the Annual General Meeting shall be fifteen (15) members or one half of the club membership, whichever is the lesser. This is based on the membership list at the time that notice of the meeting is given.
     4.4 At an Annual General Meeting:
       4.4.1 Reports shall be presented by at least the President and the Treasurer;
       4.4.2 Full financial reports shall be presented and adopted;


### PR DESCRIPTION
- 1.5.9 Revise ""...during the first or second session..."" to ""...during the first, second or thid term...""
- 2.5 Revise ""Session One"" to ""Term One""
- 2.7 Revise ""Notwithstanding clause 2.8"" to ""Notwithstanding clause 2.9""
- 2.8 Revise ""Notwithstanding clause 2.8"" to ""Notwithstanding clause 2.9""
- 4.4.3 Reference to 4.14 has a lower standard of meeting/voting as it applies to Meetings and not AGMs/EGMs. In this case, a new Executive must be elected by a quorum of full members and not just 50% of voting members of the executive. Either remove ""in accordance with Section 4.14"" or change
- 4.12.2 Remove unnecessary clause due to self-referencing
- Remove 6.2.1 as it is now outdated
- 1.4 Revise ""Organizations"" to ""Organisations""
- 2.2 Revise ""recognized"" to ""recognised""
- 3.4.3 Recommend including 3.4.4 from the Constitution Template
- 3.8.4n Remove comma at end of clause
- 3.8.5a Revise ""it's"" to ""its""
- 4.3 Recommend updating to 4.3 of the Constitution Template
- 4.8 Revise ""To petition Extraordinary General Meeting fifteen..."" to ""To petition for an Extraordinary General Meeting, fifteen...""
- 4.12.1 Revise ""All Executive Resolutions (Voting) at meetings shall subject to requirements outlined in Section 4.13"" to ""All Executive Resolutions (Voting) at meetings shall be subject to requirements outlined in Section 4.13""
- 4.16.6.5 Remove unnecessary semi-colon
- 4.17 Remove unnecessary semi-colon
- 4.17.2 Remove unnecessary semi-colon
- 4.18.2.1.2 Revise ""and"" to prior sub-clause and consequently capitalise ""members""
- 4.18.2.2.3 Revise ""and"" to prior sub-clause and consequently capitalise ""voting"""